### PR TITLE
Fix unicode in file causing build fail

### DIFF
--- a/builder/frameworks/QDL.py
+++ b/builder/frameworks/QDL.py
@@ -119,7 +119,7 @@ class QDL:
         rx = self.s.read(1) # read footer 7E
         b += rx
         ASSERT(1 == len(rx), 'read() footer size')
-        ASSERT(b'\x7E' == rx, 'read() fооter')    
+        ASSERT(b'\x7E' == rx, 'read() footer')    
         DBG('[{:02X}] <<<'.format(command) + PrintHex(b))  
         PB_STEP()
         return data     


### PR DESCRIPTION
Apparent unicode in spelling of `footer` was causing Python to choke when trying to process the file. 

```
SyntaxError: Non-ASCII character ‘\xd0’ in file C:\users\embed\.platformio\platforms\quectel\builder\frameworks\QDL.py on line 122, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

Mention here: https://community.platformio.org/t/error-while-creating-project-using-the-platformio/10777/2